### PR TITLE
Fix plugin feature custom cmake not working

### DIFF
--- a/features/plugin/CMakeLists.txt
+++ b/features/plugin/CMakeLists.txt
@@ -17,7 +17,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/plugin/src/config.h.in"
     "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
 # Process any package-specific customizations
-include(plugin OPTIONAL)
+include(plugin.cmake OPTIONAL)
 
 # Our plugin source and scripts are in a subdirectory
 set(BRO_PLUGIN_BASE "${CMAKE_CURRENT_SOURCE_DIR}/plugin")


### PR DESCRIPTION
I found that the logic written in `plugin.cmake` doesn't work.  According to my investigation, it is caused by cmake incorrectly including `plugin` directory instead of `plugin.cmake` file. So I add the suffix to make sure cmake includes the correct file.

This is my cmake version:
```
cmake version 3.22.1
```