### PR TITLE
Pin pre-commit GH action to ubuntu-20.04.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: zeekurity/zeek
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
It seems that the GH ubuntu:latest image now ships with a libc which
has too old version symbols to support the Python toolchain installed by
`actions/setup-python`. This looks like a bug on their end which might
well be transient, but still causes failures for us.

This PR switches the runner for the pre-commit action to ubuntu-20.04
which seems unaffected by this issue.