### PR TITLE
analyzers: Template in default log_policy

### DIFF
--- a/features/spicy-file-analyzer/scripts/main.zeek
+++ b/features/spicy-file-analyzer/scripts/main.zeek
@@ -17,6 +17,9 @@ export {
 		content: string &optional &log;
 	};
 
+	## A default logging policy hook for the stream.
+	global log_policy: Log::PolicyHook;
+
 	## Default hook into @ANALYZER@ logging.
 	global log_@ANALYZER_LOWER@: event(info: Info);
 }
@@ -27,7 +30,7 @@ redef record fa_file += {
 
 event zeek_init() &priority=5
 	{
-	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@"]);
+	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@", $policy=log_policy]);
 	}
 
 hook set_file(f: fa_file) &priority=5

--- a/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-one-unit@
+++ b/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-one-unit@
@@ -23,6 +23,9 @@ export {
 		reply: string &optional &log;
 	};
 
+	## A default logging policy hook for the stream.
+	global log_policy: Log::PolicyHook;
+
 	## Default hook into @ANALYZER@ logging.
 	global log_@ANALYZER_LOWER@: event(rec: Info);
 
@@ -43,7 +46,7 @@ redef likely_server_ports += { ports };
 
 event zeek_init() &priority=5
 	{
-	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@"]);
+	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@", $policy=log_policy]);
 	}
 
 # Initialize logging state.

--- a/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-two-units@
+++ b/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-two-units@
@@ -23,6 +23,9 @@ export {
 		reply: string &optional &log;
 	};
 
+	## A default logging policy hook for the stream.
+	global log_policy: Log::PolicyHook;
+
 	## Default hook into @ANALYZER@ logging.
 	global log_@ANALYZER_LOWER@: event(rec: Info);
 
@@ -43,7 +46,7 @@ redef likely_server_ports += { ports };
 
 event zeek_init() &priority=5
 	{
-	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@"]);
+	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@", $policy=log_policy]);
 	}
 
 # Initialize logging state.


### PR DESCRIPTION
Template in a default log_policy hook as log streams should always provide it. This allows to use the established `hook Module::log_policy()` pattern with analyzers created using package-template by default.