### PR TITLE
analyzers: Remove spicy:: prefix

### DIFF
--- a/features/spicy-file-analyzer/analyzer/@ANALYZER_LOWER@.evt
+++ b/features/spicy-file-analyzer/analyzer/@ANALYZER_LOWER@.evt
@@ -10,7 +10,7 @@ import Zeek_@ANALYZER@;
 #
 #   https://docs.zeek.org/projects/spicy/en/latest/zeek.html#interface-definitions-evt-files
 #
-file analyzer spicy::@ANALYZER@:
+file analyzer @ANALYZER@:
     parse with @ANALYZER@::@UNIT@,
     mime-type application/x-@ANALYZER_LOWER@;
 

--- a/features/spicy-packet-analyzer/analyzer/@ANALYZER_LOWER@.evt
+++ b/features/spicy-packet-analyzer/analyzer/@ANALYZER_LOWER@.evt
@@ -1,7 +1,7 @@
 import @ANALYZER@;
 import Zeek_@ANALYZER@;
 
-packet analyzer spicy::@ANALYZER@:
+packet analyzer @ANALYZER@:
     parse with @ANALYZER@::@UNIT@;
 
 # TODO: Connect Spicy-side events with Zeek-side events. The example just

--- a/features/spicy-packet-analyzer/scripts/main.zeek
+++ b/features/spicy-packet-analyzer/scripts/main.zeek
@@ -7,12 +7,7 @@ event zeek_init() &priority=20
 	# TODO: Our example here models a custom protocol sitting between
 	# Ethernet and IP. The following sets that up, using a custom ether
 	# type 0x88b5. Adapt as suitable, some suggestions in comments.
-
-	@if ( Version::number >= 50200 )
-	local analyzer = PacketAnalyzer::ANALYZER_SPICY_@ANALYZER_UPPER@;
-	@else
-	local analyzer = PacketAnalyzer::ANALYZER_SPICY__@ANALYZER_UPPER@;
-	@endif
+	local analyzer = PacketAnalyzer::ANALYZER_@ANALYZER_UPPER@;
 
 	# Activate our analyzer on top of Ethernet.
 	PacketAnalyzer::register_packet_analyzer(PacketAnalyzer::ANALYZER_ETHERNET, 0x88b5, analyzer);

--- a/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-one-unit@
+++ b/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-one-unit@
@@ -6,7 +6,7 @@ import Zeek_@ANALYZER@;
 #
 #   https://docs.zeek.org/projects/spicy/en/latest/zeek.html#interface-definitions-evt-files
 #
-protocol analyzer spicy::@ANALYZER@ over @PROTOCOL_UPPER@:
+protocol analyzer @ANALYZER@ over @PROTOCOL_UPPER@:
     parse originator with @ANALYZER@::@UNIT@,
     parse responder with @ANALYZER@::@UNIT@,
     port 12345/@PROTOCOL_LOWER@; # adapt port number in main.zeek accordingly

--- a/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-two-units@
+++ b/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-two-units@
@@ -6,7 +6,7 @@ import Zeek_@ANALYZER@;
 #
 #   https://docs.zeek.org/projects/spicy/en/latest/zeek.html#interface-definitions-evt-files
 #
-protocol analyzer spicy::@ANALYZER@ over @PROTOCOL_UPPER@:
+protocol analyzer @ANALYZER@ over @PROTOCOL_UPPER@:
     parse originator with @ANALYZER@::@UNIT_ORIG@,
     parse responder with @ANALYZER@::@UNIT_RESP@,
     port 12345/@PROTOCOL_LOWER@; # adapt port number in main.zeek accordingly

--- a/features/spicy-protocol-analyzer/testing/tests/availability.zeek
+++ b/features/spicy-protocol-analyzer/testing/tests/availability.zeek
@@ -1,3 +1,3 @@
 # @TEST-DOC: Check that the @ANALYZER@ analyzer is available.
 #
-# @TEST-EXEC: zeek -NN | grep -Eqi 'ANALYZER_SPICY__?@ANALYZER_UPPER@'
+# @TEST-EXEC: zeek -NN | grep -Eqi 'ANALYZER__?@ANALYZER_UPPER@'


### PR DESCRIPTION
As described #11, the `spicy::` prefix in evt files causes the generated analyzer tag to contain "SPICY_". This in turn trickles through to conn.log's service field.

Closes #11.