### PR TITLE
Fix error message when combining `plugin` and `spicy-*` features.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ class Package(zeekpkg.template.Package):
 
         if have_plugin and analyzers > 0:
             raise zeekpkg.template.InputError(
-                'the "plugin" and "spicy-protocol-analyzer" features are mutually exclusive'
+                'the "plugin" and "spicy-[file|packet|protocol]-analyzer" features are mutually exclusive'
             )
 
         if analyzers > 1:


### PR DESCRIPTION
Closes #21.