### PR TITLE
spicy-protocol-analyzer: Change from ports in .evt to register_for_ports()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: trailing-whitespace
     exclude: .*/Baseline
@@ -10,36 +10,36 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/maxwinterstein/shfmt-py
-  rev: v3.4.3.1
+  rev: v3.7.0.1
   hooks:
   - id: shfmt
     args: [-w, -i, '4', -ci]
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.9.0.2
+  rev: v0.9.0.6
   hooks:
   - id: shellcheck
 
 - repo: https://github.com/PyCQA/pylint.git
-  rev: v2.16.2
+  rev: v3.0.1
   hooks:
   - id: pylint
     additional_dependencies:
     - zkg
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.7.0
+  rev: v2.11.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/psf/black
-  rev: 23.1a1
+  rev: 23.10.1
   hooks:
   - id: black
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.1
+  rev: v3.15.0
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
@@ -65,6 +65,6 @@ repos:
     - vermin
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.16.12
+  rev: v1.16.22
   hooks:
   - id: typos

--- a/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-one-unit@
+++ b/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-one-unit@
@@ -8,8 +8,7 @@ import Zeek_@ANALYZER@;
 #
 protocol analyzer @ANALYZER@ over @PROTOCOL_UPPER@:
     parse originator with @ANALYZER@::@UNIT@,
-    parse responder with @ANALYZER@::@UNIT@,
-    port 12345/@PROTOCOL_LOWER@; # adapt port number in main.zeek accordingly
+    parse responder with @ANALYZER@::@UNIT@;
 
 # TODO: Connect Spicy-side events with Zeek-side events. The example just
 # defines a simple example event that forwards the raw data (which in practice

--- a/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-two-units@
+++ b/features/spicy-protocol-analyzer/analyzer/@ANALYZER_LOWER@.evt@ALT-two-units@
@@ -8,8 +8,7 @@ import Zeek_@ANALYZER@;
 #
 protocol analyzer @ANALYZER@ over @PROTOCOL_UPPER@:
     parse originator with @ANALYZER@::@UNIT_ORIG@,
-    parse responder with @ANALYZER@::@UNIT_RESP@,
-    port 12345/@PROTOCOL_LOWER@; # adapt port number in main.zeek accordingly
+    parse responder with @ANALYZER@::@UNIT_RESP@;
 
 # TODO: Connect Spicy-side events with Zeek-side events. The example just
 # defines simple example events that forwards the raw data (which in practice

--- a/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-one-unit@
+++ b/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-one-unit@
@@ -6,6 +6,12 @@ export {
 	## Log stream identifier.
 	redef enum Log::ID += { LOG };
 
+	## The ports to register @ANALYZER@ for.
+	const ports = {
+		# TODO: Replace with actual port(s).
+		12345/@PROTOCOL_LOWER@,
+	} &redef;
+
 	## Record type containing the column fields of the @ANALYZER@ log.
 	type Info: record {
 		## Timestamp for when the activity happened.
@@ -37,16 +43,13 @@ redef record connection += {
 	@ANALYZER_LOWER@: Info &optional;
 };
 
-const ports = {
-	# TODO: Replace with actual port(s).
-	12345/@PROTOCOL_LOWER@ # adapt port number in @ANALYZER_LOWER@.evt accordingly
-};
-
 redef likely_server_ports += { ports };
 
 event zeek_init() &priority=5
 	{
 	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@", $policy=log_policy]);
+
+	Analyzer::register_for_ports(Analyzer::ANALYZER_@ANALYZER_UPPER@, ports);
 	}
 
 # Initialize logging state.

--- a/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-two-units@
+++ b/features/spicy-protocol-analyzer/scripts/main.zeek@ALT-two-units@
@@ -6,6 +6,12 @@ export {
 	## Log stream identifier.
 	redef enum Log::ID += { LOG };
 
+	## The ports to register @ANALYZER@ for.
+	const ports = {
+		# TODO: Replace with actual port(s).
+		12345/@PROTOCOL_LOWER@ # adapt port number in @ANALYZER_LOWER@.evt accordingly
+	} &redef;
+
 	## Record type containing the column fields of the @ANALYZER@ log.
 	type Info: record {
 		## Timestamp for when the activity happened.
@@ -37,16 +43,13 @@ redef record connection += {
 	@ANALYZER_LOWER@: Info &optional;
 };
 
-const ports = {
-	# TODO: Replace with actual port(s).
-	12345/@PROTOCOL_LOWER@ # adapt port number in @ANALYZER_LOWER@.evt accordingly
-};
-
 redef likely_server_ports += { ports };
 
 event zeek_init() &priority=5
 	{
 	Log::create_stream(@ANALYZER@::LOG, [$columns=Info, $ev=log_@ANALYZER_LOWER@, $path="@ANALYZER_LOWER@", $policy=log_policy]);
+
+	Analyzer::register_for_ports(Analyzer::ANALYZER_@ANALYZER_UPPER@, ports);
 	}
 
 # Initialize logging state.


### PR DESCRIPTION
The Zeek/Spicy integration for ports when used in .evt files is lacking. Two related issues are zeek/zeek#3432 and zeek/zeek#3318. Further, it's currently not possible to prevent/unregister/remove a ports entry for an analyzer at runtime, even when running Zeek in bare mode.

On top of that, recompiling an analyzer to change the ports it is used for isn't a great development workflow and hinders testing.

Avoid this by changing the template to provide a redef'ble module constant and use the classic `Analyzer::register_for_ports()` mechanism.

Closes #27