### PR TITLE
diff-remove-timestamps: Use sed -E directly

### DIFF
--- a/package/testing/Scripts/diff-remove-timestamps
+++ b/package/testing/Scripts/diff-remove-timestamps
@@ -2,12 +2,5 @@
 #
 # Replace anything which looks like timestamps with XXXs (including the #start/end markers in logs).
 
-# Get us "modern" regexps with sed.
-if [ "$(uname)" == "Linux" ]; then
-    sed="sed -r"
-else
-    sed="sed -E"
-fi
-
-$sed 's/(0\.000000)|([0-9]{9,10}\.[0-9]{2,8})/XXXXXXXXXX.XXXXXX/g' |
-    $sed 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'
+sed -E 's/(0\.000000)|([0-9]{9,10}\.[0-9]{2,8})/XXXXXXXXXX.XXXXXX/g' |
+    sed -E 's/^ *#(open|close).(19|20)..-..-..-..-..-..$/#\1 XXXX-XX-XX-XX-XX-XX/g'


### PR DESCRIPTION
On any sufficiently modern Linux distro, sed -E will work.