### PR TITLE
Implement abstract method in derived class

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -136,6 +136,9 @@ class GithubCi(zeekpkg.template.Feature):
     def contentdir(self):
         return os.path.join("features", self.name())
 
+    def validate(self, tmpl):
+        pass
+
 
 class SpicyAnalyzer(zeekpkg.template.Feature):
     """Base class for Spicy-based analyzers."""


### PR DESCRIPTION
At least with python-3.11 the code does not pass as is,

```.console
$ zkg create --features=spicy-protocol-analyzer --packagedir myprotocol
2024-05-23 07:42:37 ERROR    problem during template instantiation: Can't instantiate abstract class GithubCi with abstract method validate
Traceback (most recent call last):
  File "/usr/local/zeek/bin/zkg", line 2223, in cmd_create
    features = tmpl.features()
               ^^^^^^^^^^^^^^^
  File "/usr/local/zeek/var/lib/zkg/clones/template/package-template/__init__.py", line 402, in features
    GithubCi(),
    ^^^^^^^^^^
TypeError: Can't instantiate abstract class GithubCi with abstract method validate
error: problem during template instantiation: Can't instantiate abstract class GithubCi with abstract method validate
```