### PR TITLE
spicy_add_analyzer: Do not use SCRIPTS

### DIFF
--- a/features/spicy-protocol-analyzer/analyzer/CMakeLists.txt
+++ b/features/spicy-protocol-analyzer/analyzer/CMakeLists.txt
@@ -2,5 +2,4 @@ spicy_add_analyzer(
     NAME @ANALYZER@
     PACKAGE_NAME @NAME@
     SOURCES @ANALYZER_LOWER@.spicy @ANALYZER_LOWER@.evt zeek_@ANALYZER_LOWER@.spicy
-    SCRIPTS __load__.zeek main.zeek dpd.sig
 )


### PR DESCRIPTION
The SCRIPTS parameter for spicy_add_analyzer() is not functional, so rendering it into CMakeLists.txt is confusing [1]. Remove it.

These scripts are installed via zkg.meta's script_dir here in the template.

[1] https://github.com/zeek/cmake/issues/97