### PR TITLE
Globally exclude Baseline directories from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
+exclude: .*/Baseline
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:
   - id: trailing-whitespace
-    exclude: .*/Baseline
   - id: end-of-file-fixer
-    exclude: .*/Baseline
   - id: check-yaml
   - id: check-added-large-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: .*/Baseline
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -16,30 +16,30 @@ repos:
     args: [-w, -i, '4', -ci]
 
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.9.0.6
+  rev: v0.10.0.1
   hooks:
   - id: shellcheck
 
 - repo: https://github.com/PyCQA/pylint.git
-  rev: v3.0.1
+  rev: v3.2.7
   hooks:
   - id: pylint
     additional_dependencies:
     - zkg
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.11.0
+  rev: v2.14.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 24.8.0
   hooks:
   - id: black
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
+  rev: v3.17.0
   hooks:
   - id: pyupgrade
     args: [--py37-plus]
@@ -65,6 +65,6 @@ repos:
     - vermin
 
 - repo: https://github.com/crate-ci/typos
-  rev: v1.16.22
+  rev: v1.24.3
   hooks:
   - id: typos

--- a/__init__.py
+++ b/__init__.py
@@ -5,6 +5,7 @@ https://docs.zeek.org/projects/package-manager/en/stable/api/template.html
 
 for details.
 """
+
 from datetime import date
 import glob
 import os


### PR DESCRIPTION
Users might want to add e.g., YAML files in baselines which we might
have triggered on via other hooks which did not explicitly exclude them.
Instead globally exclude any `Baseline` directory from linting.