### PR TITLE
Ubuntu 20.04 is EOL, bump workflow runners in the template's CI feature

### DIFF
--- a/features/github-ci/.github/workflows/zeek-matrix.yml
+++ b/features/github-ci/.github/workflows/zeek-matrix.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     name: test-${{ matrix.zeekver }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/features/github-ci/.github/workflows/zeek-nightly.yml
+++ b/features/github-ci/.github/workflows/zeek-nightly.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-nightly:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: zeek/action-zkg-install@v2
       with:


### PR DESCRIPTION
I'll tag a new version when this is merged.