### PR TITLE
Avoid incorrect `spicy_` prefix in Spicy DPD

### DIFF
--- a/features/spicy-protocol-analyzer/scripts/dpd.sig
+++ b/features/spicy-protocol-analyzer/scripts/dpd.sig
@@ -4,5 +4,5 @@
 # signature dpd_@ANALYZER_LOWER@ {
 #     ip-proto == @PROTOCOL_LOWER@
 #     payload /^\x11\x22\x33\x44/ # TODO: Detect your protocol here.
-#     enable "spicy_@ANALYZER@"
+#     enable "@ANALYZER@"
 # }


### PR DESCRIPTION
Closes #47

The `spicy_` prefix to `ANALYZER` is because Spicy analyzers were recommended to start with `spicy::`. However, this is actually impossible in the template, since colons are not valid in analyzer names within the template.

The recommendation is also stale, so the documentation should be updated to reflect the new reality.